### PR TITLE
Add abi3 stable ABI and free-threaded support

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -58,14 +58,18 @@ jobs:
 
       - name: Install wheel
         run: |
-          # Find the wheel matching this Python version.
+          # Try version-specific wheel first (cp310, cp311), then abi3.
           PYVER="cp$(echo ${{ matrix.python-version }} | tr -d '.')"
-          WHEEL=$(ls wheelhouse/iree_tokenizer-*-${PYVER}-*.manylinux*.whl 2>/dev/null | head -1)
+          WHEEL=$(ls wheelhouse/iree_tokenizer-*-${PYVER}-${PYVER}-*.manylinux*.whl 2>/dev/null | head -1)
+          if [ -z "$WHEEL" ]; then
+            WHEEL=$(ls wheelhouse/iree_tokenizer-*-*-abi3-*.manylinux*.whl 2>/dev/null | head -1)
+          fi
           if [ -z "$WHEEL" ]; then
             echo "No wheel found for ${PYVER}, listing available:"
             ls wheelhouse/
             exit 1
           fi
+          echo "Installing: ${WHEEL}"
           pip install "${WHEEL}"
 
       - name: Install test deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,8 @@ endif()
 # nanobind
 ################################################################################
 
-find_package(Python 3.10 COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(Python 3.10 COMPONENTS Interpreter Development.Module
+  Development.SABIModule REQUIRED)
 
 # nanobind: prefer system install, fall back to FetchContent.
 find_package(nanobind QUIET)
@@ -139,7 +140,7 @@ endif()
 ################################################################################
 
 nanobind_add_module(_iree_tokenizer
-  NB_STATIC LTO
+  NB_STATIC LTO STABLE_ABI FREE_THREADED
   src/bindings/module.cc
   src/bindings/tokenizer.cc
   src/bindings/streaming.cc

--- a/build_tools/build_linux_packages.py
+++ b/build_tools/build_linux_packages.py
@@ -40,9 +40,7 @@ MANYLINUX_IMAGES = {
 DEFAULT_PYTHON_VERSIONS = [
     "cp310-cp310",
     "cp311-cp311",
-    "cp312-cp312",
-    "cp313-cp313",
-    "cp314-cp314",
+    "cp312-cp312",  # Produces abi3 wheel covering 3.12+
 ]
 
 
@@ -226,8 +224,10 @@ def run_in_docker(args: argparse.Namespace):
         )
 
         # Find any pre-existing wheels matching this version to clean them.
+        # Wheels may be version-specific (cp310-cp310) or abi3 (cp312-abi3).
         arch = platform.machine()
-        for old in output_dir.glob(f"iree_tokenizer-*-{pyver}-linux_{arch}.whl"):
+        cpver = pyver.split("-")[0]  # e.g. "cp312" from "cp312-cp312"
+        for old in output_dir.glob(f"iree_tokenizer-*-{cpver}-*-linux_{arch}.whl"):
             old.unlink()
             print(f"  Cleaned old wheel: {old.name}")
 
@@ -235,8 +235,9 @@ def run_in_docker(args: argparse.Namespace):
 
         if not args.no_repair:
             # Find the just-built generic wheel and repair it.
+            # May be version-specific or abi3.
             generic_wheels = list(
-                output_dir.glob(f"iree_tokenizer-*-{pyver}-linux_{arch}.whl")
+                output_dir.glob(f"iree_tokenizer-*-{cpver}-*-linux_{arch}.whl")
             )
             if not generic_wheels:
                 print(f"WARNING: No wheel found for {pyver} after build")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ bench = ["tokenizers", "tiktoken", "rich"]
 [tool.scikit-build]
 cmake.build-type = "Release"
 wheel.packages = ["src/iree"]
+wheel.py-api = "cp312"
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"


### PR DESCRIPTION
## Summary

- Add `STABLE_ABI` and `FREE_THREADED` flags to nanobind module
- Single `cp312-abi3` wheel covers Python 3.12, 3.13, 3.14+
- Still build version-specific wheels for 3.10 and 3.11
- 3 wheels instead of 5 per platform

## Test plan

- [x] Built cp312-abi3 wheel locally with podman
- [x] Installed on Python 3.14 host — 37/37 tests pass
- [x] CI: build_packages builds 3 wheels, test_wheels passes on 3.10-3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)