### PR TITLE
Add -O3 globally and optional -march=native

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,28 @@ if(IREE_TOKENIZER_ENABLE_UBSAN)
 endif()
 
 ################################################################################
+# Native Architecture Optimization
+################################################################################
+
+option(IREE_TOKENIZER_NATIVE_ARCH
+  "Compile with -march=native for host CPU optimization" OFF)
+
+# Force -O3 in Release builds (CMake defaults to -O2).
+if(NOT MSVC)
+  string(REPLACE "-O2" "-O3" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+  string(REPLACE "-O2" "-O3" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+endif()
+
+if(IREE_TOKENIZER_NATIVE_ARCH)
+  if(MSVC)
+    message(WARNING "IREE_TOKENIZER_NATIVE_ARCH: -march=native not supported on MSVC, ignoring")
+  else()
+    message(STATUS "IREE_TOKENIZER_NATIVE_ARCH=ON: compiling with -march=native")
+    add_compile_options(-march=native)
+  endif()
+endif()
+
+################################################################################
 # Python Extension Module
 ################################################################################
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ cmake --build build-asan
 ln -sf build-asan/_iree_tokenizer*.so src/iree/tokenizer/
 LD_PRELOAD=$(clang++ -print-file-name=libclang_rt.asan.so) \
   ASAN_OPTIONS=detect_leaks=0 PYTHONPATH=src pytest tests/ -v
+
+# Optimized local build (-march=native)
+IREE_TOKENIZER_NATIVE_ARCH=ON pip install .
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ regex = '"package-version":\s*"(?P<value>[^"]+)"'
 
 [tool.scikit-build.cmake.define]
 IREE_SOURCE_DIR = {env = "IREE_SOURCE_DIR", default = ""}
+IREE_TOKENIZER_NATIVE_ARCH = {env = "IREE_TOKENIZER_NATIVE_ARCH", default = "OFF"}
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- Force `-O3` in Release builds (CMake defaults to `-O2`)
- Add `IREE_TOKENIZER_NATIVE_ARCH` option for `-march=native` local builds
- Exposed as env var: `IREE_TOKENIZER_NATIVE_ARCH=ON pip install .`
- Prints CMake status message when enabled for easy verification

## Test plan

- [x] Verified `-O3 -DNDEBUG` in CMakeCache.txt for Release builds
- [x] Verified `IREE_TOKENIZER_NATIVE_ARCH=ON` prints status and adds `-march=native`
- [x] CI passes (no behavioral change for default builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)