### PR TITLE
Add Windows wheel build

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           python-version: "3.12"
 
+      - uses: ilammy/msvc-dev-cmd@v1
+
       - name: Install build deps
         run: pip install scikit-build-core nanobind numpy ninja
 


### PR DESCRIPTION
## Summary

- Add `build_windows_x86_64` job: builds wheel on `windows-latest` with MSVC
- Test Windows wheels on Python 3.12, 3.13, 3.14
- Linux test matrix unchanged (3.10-3.14)
- Cross-platform wheel install step using bash shell

## Test plan

- [x] CI: Windows build job succeeds
- [x] CI: Windows test_wheels jobs pass on 3.12-3.14
- [x] CI: Linux jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)