### PR TITLE
Add release tooling and set version 0.1.0

### DIFF
--- a/build_tools/make_release.py
+++ b/build_tools/make_release.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Create a release: update version, commit, tag, optionally bump to dev.
+
+Usage:
+    # Release 0.1.0, then bump to 0.2.0.dev0:
+    python build_tools/make_release.py --version 0.1.0 --bump-dev
+
+    # Release 0.1.0 without post-release bump:
+    python build_tools/make_release.py --version 0.1.0
+
+    # Dry run (show what would happen):
+    python build_tools/make_release.py --version 0.1.0 --bump-dev --dry-run
+
+After running, manually:
+    git push origin main --tags
+    python build_tools/publish_artifacts.py --latest
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSION_FILE = REPO_ROOT / "version.json"
+
+
+def run(cmd: list[str], dry_run: bool = False):
+    print(f"+ {' '.join(cmd)}", flush=True)
+    if not dry_run:
+        subprocess.run(cmd, check=True, cwd=REPO_ROOT)
+
+
+def read_version_json() -> dict:
+    with open(VERSION_FILE) as f:
+        return json.load(f)
+
+
+def write_version_json(data: dict, dry_run: bool = False):
+    content = json.dumps(data, indent=2) + "\n"
+    print(f"  version.json: package-version = {data['package-version']}")
+    if not dry_run:
+        with open(VERSION_FILE, "w") as f:
+            f.write(content)
+
+
+def validate_version(version: str):
+    """Validate PEP 440 release version (X.Y.Z)."""
+    if not re.match(r"^\d+\.\d+\.\d+$", version):
+        sys.exit(f"Invalid version '{version}': expected X.Y.Z (e.g., 0.1.0)")
+
+
+def next_dev_version(version: str) -> str:
+    """Bump minor version and append .dev0: 0.1.0 -> 0.2.0.dev0."""
+    parts = version.split(".")
+    parts[1] = str(int(parts[1]) + 1)
+    parts[2] = "0"
+    return ".".join(parts) + ".dev0"
+
+
+def check_clean_tree(dry_run: bool):
+    if dry_run:
+        return
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    if result.stdout.strip():
+        sys.exit("Working tree is not clean. Commit or stash changes first.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create an iree-tokenizer release")
+    parser.add_argument(
+        "--version", required=True, help="Release version (e.g., 0.1.0)"
+    )
+    parser.add_argument(
+        "--bump-dev",
+        action="store_true",
+        help="After tagging, bump to next dev version",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without making changes",
+    )
+    args = parser.parse_args()
+
+    validate_version(args.version)
+    check_clean_tree(args.dry_run)
+
+    data = read_version_json()
+    tag = f"v{args.version}"
+
+    # Step 1: Set release version.
+    print(f"\n=== Setting version to {args.version} ===")
+    data["package-version"] = args.version
+    write_version_json(data, args.dry_run)
+    run(["git", "add", "version.json"], args.dry_run)
+    run(["git", "commit", "-m", f"Release {tag}"], args.dry_run)
+
+    # Step 2: Create tag.
+    print(f"\n=== Creating tag {tag} ===")
+    run(["git", "tag", tag], args.dry_run)
+
+    # Step 3: Optionally bump to next dev version.
+    if args.bump_dev:
+        dev = next_dev_version(args.version)
+        print(f"\n=== Bumping to {dev} ===")
+        data["package-version"] = dev
+        write_version_json(data, args.dry_run)
+        run(["git", "add", "version.json"], args.dry_run)
+        run(["git", "commit", "-m", f"Bump to {dev}"], args.dry_run)
+
+    # Done.
+    print(f"\n{'='*60}")
+    print("Done! Next steps:")
+    print(f"  git push origin main --tags")
+    print(f"  # Wait for CI to build wheels, then:")
+    print(f"  python build_tools/publish_artifacts.py --latest")
+    if args.dry_run:
+        print("\n(dry run — no changes were made)")
+
+
+if __name__ == "__main__":
+    main()

--- a/build_tools/publish_artifacts.py
+++ b/build_tools/publish_artifacts.py
@@ -29,7 +29,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-REPO = "stellaraccident/py-tokenizer"
+DEFAULT_REPO = "iree-org/iree-tokenizer"
 
 
 def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
@@ -37,14 +37,14 @@ def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, check=True, **kwargs)
 
 
-def get_latest_run_id() -> str:
+def get_latest_run_id(repo: str) -> str:
     result = run(
         [
             "gh",
             "run",
             "list",
             "--repo",
-            REPO,
+            repo,
             "--workflow",
             "build_packages.yml",
             "--branch",
@@ -67,8 +67,9 @@ def get_latest_run_id() -> str:
     return run_id
 
 
-def download_artifacts(run_id: str, dest: Path):
+def download_artifacts(run_id: str, repo: str, dest: Path):
     dest.mkdir(parents=True, exist_ok=True)
+    # Download all wheel artifacts from the run.
     run(
         [
             "gh",
@@ -76,13 +77,19 @@ def download_artifacts(run_id: str, dest: Path):
             "download",
             run_id,
             "--repo",
-            REPO,
-            "--name",
-            "wheels-linux-x86_64",
+            repo,
+            "--pattern",
+            "wheels-*",
             "--dir",
             str(dest),
         ]
     )
+    # gh downloads into subdirectories; flatten them.
+    for subdir in dest.iterdir():
+        if subdir.is_dir():
+            for whl in subdir.glob("*.whl"):
+                whl.rename(dest / whl.name)
+            subdir.rmdir()
 
 
 def upload_wheels(wheel_dir: Path, test_pypi: bool, dry_run: bool):
@@ -131,19 +138,24 @@ def main():
         default=None,
         help="Directory to download wheels into (default: temp dir)",
     )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"GitHub repo (default: {DEFAULT_REPO})",
+    )
     args = parser.parse_args()
 
-    run_id = args.run_id or get_latest_run_id()
+    run_id = args.run_id or get_latest_run_id(args.repo)
     print(f"Using run ID: {run_id}")
 
     if args.output_dir:
         dest = Path(args.output_dir)
-        download_artifacts(run_id, dest)
+        download_artifacts(run_id, args.repo, dest)
         upload_wheels(dest, args.test_pypi, args.dry_run)
     else:
         with tempfile.TemporaryDirectory(prefix="iree-tokenizer-wheels-") as tmpdir:
             dest = Path(tmpdir)
-            download_artifacts(run_id, dest)
+            download_artifacts(run_id, args.repo, dest)
             upload_wheels(dest, args.test_pypi, args.dry_run)
 
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "package-version": "0.1.0.dev0",
+  "package-version": "0.1.0",
   "iree-version": "3.11.0rc20260304"
 }


### PR DESCRIPTION
## Summary
- Add `build_tools/make_release.py` — automates version bump, commit, tag, and optional dev version bump (`--version X.Y.Z [--bump-dev] [--dry-run]`)
- Update `build_tools/publish_artifacts.py` — point repo to `iree-org/iree-tokenizer`, add `--repo` flag, download all platform wheel artifacts (`wheels-*` pattern) with subdirectory flattening
- Set `version.json` package-version to `0.1.0`

## Release workflow
```bash
# Create release (sets version, commits, tags, bumps to dev):
python build_tools/make_release.py --version 0.1.0 --bump-dev

# Push:
git push origin main --tags

# Wait for CI, then publish wheels:
python build_tools/publish_artifacts.py --latest
```

## Test plan
- [ ] `python build_tools/make_release.py --version 0.1.0 --bump-dev --dry-run` shows expected steps
- [ ] `publish_artifacts.py --latest --dry-run` resolves latest run ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)