### PR TITLE
Harden bindings, CI, and build for security

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -17,6 +17,9 @@ concurrency:
   group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build_linux_x86_64:
     runs-on: ubuntu-24.04
@@ -53,6 +56,9 @@ jobs:
       - name: Clone IREE
         run: |
           $IREE_VERSION = python -c "import json; print(json.load(open('version.json'))['iree-version'])"
+          if ($IREE_VERSION -notmatch '^[a-zA-Z0-9._-]+$') {
+            Write-Error "Invalid IREE version: $IREE_VERSION"; exit 1
+          }
           git clone --depth 1 --branch "iree-$IREE_VERSION" https://github.com/iree-org/iree.git C:\iree
           git -C C:\iree submodule update --init --depth 1 third_party/flatcc third_party/benchmark
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04
@@ -44,6 +47,9 @@ jobs:
       - name: Clone IREE
         run: |
           IREE_VERSION=$(python3 -c "import json; print(json.load(open('version.json'))['iree-version'])")
+          if ! echo "$IREE_VERSION" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+            echo "Invalid IREE version: $IREE_VERSION" >&2; exit 1
+          fi
           git clone --depth 1 --branch "iree-${IREE_VERSION}" \
             https://github.com/iree-org/iree.git /tmp/iree || \
           git clone --depth 1 https://github.com/iree-org/iree.git /tmp/iree
@@ -87,6 +93,9 @@ jobs:
       - name: Clone IREE
         run: |
           IREE_VERSION=$(python3 -c "import json; print(json.load(open('version.json'))['iree-version'])")
+          if ! echo "$IREE_VERSION" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+            echo "Invalid IREE version: $IREE_VERSION" >&2; exit 1
+          fi
           git clone --depth 1 --branch "iree-${IREE_VERSION}" \
             https://github.com/iree-org/iree.git /tmp/iree || \
           git clone --depth 1 https://github.com/iree-org/iree.git /tmp/iree

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,11 +169,12 @@ nanobind_add_module(_iree_tokenizer
   src/bindings/encoding.cc
 )
 
-# nanobind requires RTTI and exceptions.
+# nanobind requires RTTI and exceptions. Enable warnings for our bindings.
 if(MSVC)
-  target_compile_options(_iree_tokenizer PRIVATE /EHsc /GR)
+  target_compile_options(_iree_tokenizer PRIVATE /EHsc /GR /W4)
 else()
-  target_compile_options(_iree_tokenizer PRIVATE -frtti -fexceptions)
+  target_compile_options(_iree_tokenizer PRIVATE
+    -frtti -fexceptions -Wall -Wextra -Wshadow)
 endif()
 
 # Link IREE tokenizer targets.

--- a/src/bindings/streaming.cc
+++ b/src/bindings/streaming.cc
@@ -19,23 +19,27 @@ namespace nb = nanobind;
 void RegisterStreaming(nb::module_& m) {
   nb::class_<EncodeStream>(m, "EncodeStream",
                            "Streaming encoder for incremental tokenization.")
-      .def("feed", &EncodeStream::Feed, nb::arg("text"),
+      .def("feed", &EncodeStream::Feed, nb::arg("text"), nb::lock_self(),
            "Feed a text chunk. Returns token IDs produced so far.")
-      .def("finalize", &EncodeStream::Finalize,
+      .def("finalize", &EncodeStream::Finalize, nb::lock_self(),
            "Flush remaining tokens. Must be called after all input is fed.")
-      .def("close", &EncodeStream::Close, "Release resources.")
+      .def("close", &EncodeStream::Close, nb::lock_self(), "Release resources.")
       .def_prop_ro("is_open", &EncodeStream::is_open)
       .def("__enter__", [](nb::object self) -> nb::object { return self; })
-      .def("__exit__", [](EncodeStream& s, nb::args) { s.Close(); });
+      .def(
+          "__exit__", [](EncodeStream& s, nb::args) { s.Close(); },
+          nb::lock_self());
 
   nb::class_<DecodeStream>(m, "DecodeStream",
                            "Streaming decoder for incremental detokenization.")
-      .def("feed", &DecodeStream::Feed, nb::arg("tokens"),
+      .def("feed", &DecodeStream::Feed, nb::arg("tokens"), nb::lock_self(),
            "Feed token IDs. Returns text produced so far.")
-      .def("finalize", &DecodeStream::Finalize,
+      .def("finalize", &DecodeStream::Finalize, nb::lock_self(),
            "Flush remaining text. Must be called after all tokens are fed.")
-      .def("close", &DecodeStream::Close, "Release resources.")
+      .def("close", &DecodeStream::Close, nb::lock_self(), "Release resources.")
       .def_prop_ro("is_open", &DecodeStream::is_open)
       .def("__enter__", [](nb::object self) -> nb::object { return self; })
-      .def("__exit__", [](DecodeStream& s, nb::args) { s.Close(); });
+      .def(
+          "__exit__", [](DecodeStream& s, nb::args) { s.Close(); },
+          nb::lock_self());
 }

--- a/src/bindings/tokenizer.cc
+++ b/src/bindings/tokenizer.cc
@@ -86,10 +86,11 @@ class TokenizerWrapper {
       const std::string& text, bool add_special_tokens) {
     auto ids = Encode(text, add_special_tokens);
     size_t n = ids.size();
-    int32_t* data = new int32_t[n];
-    std::memcpy(data, ids.data(), n * sizeof(int32_t));
-    nb::capsule owner(data, [](void* p) noexcept { delete[] (int32_t*)p; });
-    return nb::ndarray<nb::numpy, int32_t, nb::ndim<1>>(data, {n},
+    auto data = std::make_unique<int32_t[]>(n);
+    std::memcpy(data.get(), ids.data(), n * sizeof(int32_t));
+    int32_t* raw = data.release();
+    nb::capsule owner(raw, [](void* p) noexcept { delete[] (int32_t*)p; });
+    return nb::ndarray<nb::numpy, int32_t, nb::ndim<1>>(raw, {n},
                                                         std::move(owner));
   }
 
@@ -216,16 +217,18 @@ class TokenizerWrapper {
     size_t total = 0;
     for (const auto& ids : batched) total += ids.size();
 
-    int32_t* flat_data = new int32_t[total];
-    int64_t* len_data = new int64_t[batched.size()];
+    auto flat_ptr = std::make_unique<int32_t[]>(total);
+    auto len_ptr = std::make_unique<int64_t[]>(batched.size());
     size_t offset = 0;
     for (size_t i = 0; i < batched.size(); ++i) {
-      std::memcpy(flat_data + offset, batched[i].data(),
+      std::memcpy(flat_ptr.get() + offset, batched[i].data(),
                   batched[i].size() * sizeof(int32_t));
-      len_data[i] = static_cast<int64_t>(batched[i].size());
+      len_ptr[i] = static_cast<int64_t>(batched[i].size());
       offset += batched[i].size();
     }
 
+    int32_t* flat_data = flat_ptr.release();
+    int64_t* len_data = len_ptr.release();
     nb::capsule flat_owner(flat_data,
                            [](void* p) noexcept { delete[] (int32_t*)p; });
     nb::capsule len_owner(len_data,
@@ -349,8 +352,9 @@ class TokenizerWrapper {
     size_t n = token_count;
 
     // IDs array.
-    int32_t* ids_data = new int32_t[n];
-    std::memcpy(ids_data, token_ids.data(), n * sizeof(int32_t));
+    auto ids_ptr = std::make_unique<int32_t[]>(n);
+    std::memcpy(ids_ptr.get(), token_ids.data(), n * sizeof(int32_t));
+    int32_t* ids_data = ids_ptr.release();
     nb::capsule ids_owner(ids_data,
                           [](void* p) noexcept { delete[] (int32_t*)p; });
     auto ids_arr = nb::ndarray<nb::numpy, int32_t, nb::ndim<1>>(
@@ -359,11 +363,12 @@ class TokenizerWrapper {
     // Offsets array — (n, 2) of uint64.
     nb::object offsets_arr;
     if (track_offsets) {
-      uint64_t* off_data = new uint64_t[n * 2];
+      auto off_ptr = std::make_unique<uint64_t[]>(n * 2);
       for (size_t i = 0; i < n; ++i) {
-        off_data[i * 2] = offsets[i].start;
-        off_data[i * 2 + 1] = offsets[i].end;
+        off_ptr[i * 2] = offsets[i].start;
+        off_ptr[i * 2 + 1] = offsets[i].end;
       }
+      uint64_t* off_data = off_ptr.release();
       nb::capsule off_owner(off_data,
                             [](void* p) noexcept { delete[] (uint64_t*)p; });
       offsets_arr = nb::cast(nb::ndarray<nb::numpy, uint64_t, nb::ndim<2>>(
@@ -373,8 +378,9 @@ class TokenizerWrapper {
     }
 
     // Type IDs array.
-    uint8_t* tid_data = new uint8_t[n];
-    std::memcpy(tid_data, type_ids.data(), n);
+    auto tid_ptr = std::make_unique<uint8_t[]>(n);
+    std::memcpy(tid_ptr.get(), type_ids.data(), n);
+    uint8_t* tid_data = tid_ptr.release();
     nb::capsule tid_owner(tid_data,
                           [](void* p) noexcept { delete[] (uint8_t*)p; });
     auto tid_arr = nb::ndarray<nb::numpy, uint8_t, nb::ndim<1>>(
@@ -486,6 +492,11 @@ void RegisterTokenizer(nb::module_& m) {
               throw nb::value_error(("Cannot open file: " + path).c_str());
             fseek(f, 0, SEEK_END);
             long size = ftell(f);
+            if (size < 0) {
+              fclose(f);
+              throw nb::value_error(
+                  "Cannot determine file size (not a regular file?)");
+            }
             fseek(f, 0, SEEK_SET);
             std::string json(size, '\0');
             size_t read = fread(json.data(), 1, size, f);

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,193 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Security and robustness tests."""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Edge-case inputs
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCaseInputs:
+    def test_encode_empty_string(self, bpe_tokenizer):
+        ids = bpe_tokenizer.encode("")
+        assert ids == []
+
+    def test_decode_empty_list(self, bpe_tokenizer):
+        text = bpe_tokenizer.decode([])
+        assert text == ""
+
+    def test_encode_batch_empty(self, bpe_tokenizer):
+        result = bpe_tokenizer.encode_batch([])
+        assert result == []
+
+    def test_decode_batch_empty(self, bpe_tokenizer):
+        result = bpe_tokenizer.decode_batch([])
+        assert result == []
+
+    def test_encode_null_bytes(self, bpe_tokenizer):
+        """Null bytes in input should not crash."""
+        ids = bpe_tokenizer.encode("Hello\x00world")
+        assert isinstance(ids, list)
+
+    def test_encode_unicode_edge_cases(self, bpe_tokenizer):
+        """Various Unicode edge cases should not crash."""
+        for text in ["\U0001f600", "a" * 100000, "\u00e9\u00e9\u00e9"]:
+            try:
+                bpe_tokenizer.encode(text)
+            except (ValueError, TypeError):
+                pass  # Rejecting is fine, crashing is not.
+
+    def test_encode_very_long_input(self, bpe_tokenizer):
+        """Large input should not crash."""
+        ids = bpe_tokenizer.encode("x" * 50000)
+        assert len(ids) > 0
+
+
+# ---------------------------------------------------------------------------
+# Loading errors
+# ---------------------------------------------------------------------------
+
+
+class TestLoadErrors:
+    def test_from_file_nonexistent(self):
+        from iree.tokenizer import Tokenizer
+
+        with pytest.raises(ValueError, match="Cannot open"):
+            Tokenizer.from_file("/nonexistent/tokenizer.json")
+
+    def test_from_str_empty(self):
+        from iree.tokenizer import Tokenizer
+
+        with pytest.raises(Exception):
+            Tokenizer.from_str("")
+
+    def test_from_str_malformed_json(self):
+        from iree.tokenizer import Tokenizer
+
+        with pytest.raises(Exception):
+            Tokenizer.from_str("{invalid json")
+
+    def test_from_buffer_empty(self):
+        from iree.tokenizer import Tokenizer
+
+        with pytest.raises(Exception):
+            Tokenizer.from_buffer(b"")
+
+
+# ---------------------------------------------------------------------------
+# Streaming edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingEdgeCases:
+    def test_encode_stream_feed_after_finalize(self, bpe_tokenizer):
+        """Feeding after finalize should not crash."""
+        s = bpe_tokenizer.encode_stream()
+        s.feed("Hello")
+        s.finalize()
+        # May raise or return empty — either is fine, just must not crash.
+        try:
+            s.feed("more")
+        except RuntimeError:
+            pass
+
+    def test_decode_stream_feed_after_finalize(self, bpe_tokenizer):
+        """Feeding after finalize should not crash."""
+        s = bpe_tokenizer.decode_stream()
+        s.feed([72])
+        s.finalize()
+        try:
+            s.feed([73])
+        except RuntimeError:
+            pass
+
+    def test_encode_stream_double_finalize(self, bpe_tokenizer):
+        """Double finalize should not crash."""
+        s = bpe_tokenizer.encode_stream()
+        s.feed("Hello")
+        s.finalize()
+        try:
+            s.finalize()
+        except RuntimeError:
+            pass
+
+    def test_decode_stream_double_finalize(self, bpe_tokenizer):
+        """Double finalize should not crash."""
+        s = bpe_tokenizer.decode_stream()
+        s.feed([72])
+        s.finalize()
+        try:
+            s.finalize()
+        except RuntimeError:
+            pass
+
+    def test_encode_stream_feed_empty(self, bpe_tokenizer):
+        """Empty feed should be harmless."""
+        with bpe_tokenizer.encode_stream() as s:
+            ids = s.feed("")
+            assert isinstance(ids, list)
+            s.finalize()
+
+    def test_decode_stream_feed_empty(self, bpe_tokenizer):
+        """Empty feed should be harmless."""
+        with bpe_tokenizer.decode_stream() as s:
+            text = s.feed([])
+            assert isinstance(text, str)
+            s.finalize()
+
+
+# ---------------------------------------------------------------------------
+# CLI error handling
+# ---------------------------------------------------------------------------
+
+
+CLI = [sys.executable, "-m", "iree.tokenizer.cli"]
+
+
+class TestCLIErrors:
+    def test_missing_tokenizer(self):
+        """CLI without -t should exit with error."""
+        r = subprocess.run(
+            [*CLI, "encode", "--no-progress"],
+            input="Hello\n",
+            capture_output=True,
+            text=True,
+        )
+        assert r.returncode != 0
+
+    def test_nonexistent_tokenizer_file(self):
+        """CLI with nonexistent tokenizer should exit with error."""
+        r = subprocess.run(
+            [*CLI, "encode", "-t", "/nonexistent/tok.json", "--no-progress"],
+            input="Hello\n",
+            capture_output=True,
+            text=True,
+        )
+        assert r.returncode != 0
+
+    def test_decode_invalid_json_input(self):
+        """Decode with non-JSON input should handle gracefully."""
+        import pathlib
+
+        tok_path = str(
+            pathlib.Path(__file__).parent / "testdata" / "bpe_bytelevel_minimal.json"
+        )
+        r = subprocess.run(
+            [*CLI, "decode", "-t", tok_path, "--no-progress"],
+            input="not json\n",
+            capture_output=True,
+            text=True,
+        )
+        # Should fail but not crash (returncode != 0 or empty output).
+        assert r.returncode != 0 or r.stdout.strip() == ""


### PR DESCRIPTION
## Summary

- Validate `IREE_VERSION` from `version.json` with strict regex before shell interpolation (prevents CI injection via malicious PRs)
- Add `permissions: contents: read` to both CI workflows (least privilege)
- Check `ftell()` return value in `from_file` to prevent `SIZE_MAX` allocation on pipes/special files
- Use `unique_ptr` guards before nanobind capsule construction to prevent memory leaks on throw (`EncodeToArray`, `EncodeBatchToArray`, `EncodeRich`)
- Add `nb::lock_self()` to all mutating stream methods for free-threaded Python (PEP 703) thread safety
- Enable `-Wall -Wextra -Wshadow` / `/W4` compiler warnings on the extension module
- Add 20 security/robustness tests (edge-case inputs, load errors, streaming misuse, CLI error handling)

## Test plan

- [x] All 73 tests pass locally (including 20 new security tests)
- [x] Build compiles clean with new warning flags
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)